### PR TITLE
feat(data-table): per-column footer config for table and exports

### DIFF
--- a/projects/verben-ng-ui/src/lib/components/data-table/data-table.component.html
+++ b/projects/verben-ng-ui/src/lib/components/data-table/data-table.component.html
@@ -66,6 +66,8 @@
             [ngTemplateOutlet]="column.footerTemplate"
             [ngTemplateOutletContext]="getFooterContext(column)"
           ></ng-container>
+          } @else if (column.footer || column.footerFn) {
+          {{ getFooterDisplay(column) }}
           }
         </td>
         }

--- a/projects/verben-ng-ui/src/lib/components/data-table/data-table.component.ts
+++ b/projects/verben-ng-ui/src/lib/components/data-table/data-table.component.ts
@@ -21,6 +21,7 @@ import {
   FormGroupConfig,
   GroupedDataRow,
 } from './data-table.types';
+import { computeColumnFooter, formatColumnFooter } from './footer.util';
 import { TableStyles } from './style.types';
 
 @Component({
@@ -138,7 +139,12 @@ export class DataTableComponent<T> {
   }
 
   hasFooter = computed(() =>
-    this.displayColumns().some((col) => col.footerTemplate !== undefined),
+    this.displayColumns().some(
+      (col) =>
+        col.footerTemplate !== undefined ||
+        col.footer !== undefined ||
+        col.footerFn !== undefined,
+    ),
   );
 
   // Helper method to get unique identifier for a row
@@ -539,9 +545,21 @@ export class DataTableComponent<T> {
     }
   };
 
+  // Computes the declarative footer value for a column from the current data.
+  getFooterValue = (column: ColumnDefinition<T>): any => {
+    return computeColumnFooter(column, this.data());
+  };
+
+  // Renders the declarative footer value to a display string (label + value).
+  getFooterDisplay = (column: ColumnDefinition<T>): string => {
+    return formatColumnFooter(column, this.getFooterValue(column));
+  };
+
   getFooterContext(column: ColumnDefinition<T>) {
+    const value = this.getFooterValue(column);
     return {
-      $implicit: column,
+      $implicit: value,
+      value,
       column,
       data: this.data,
     };

--- a/projects/verben-ng-ui/src/lib/components/data-table/data-table.types.ts
+++ b/projects/verben-ng-ui/src/lib/components/data-table/data-table.types.ts
@@ -7,6 +7,33 @@ import {
   ValidatorFn,
 } from '@angular/forms';
 
+/** Built-in aggregations that can be computed over a column's values. */
+export type FooterAggregation = 'sum' | 'avg' | 'min' | 'max' | 'count';
+
+/**
+ * Richer declarative footer configuration for a column. Overrides the simple
+ * `footerFn` when set. Drives both the table's `<tfoot>` and exports.
+ *
+ * Value precedence (highest → lowest): `valueFn` → `aggregation` → label-only.
+ * For full control over the rendered markup use `ColumnDefinition.footerTemplate`,
+ * which takes precedence in the table (but is ignored by exports).
+ */
+export interface ColumnFooterConfig<T> {
+  /** Built-in aggregation computed over the column's values across all rows. */
+  aggregation?: FooterAggregation;
+  /**
+   * Custom reducer receiving every (non-group) row and the column.
+   * Takes precedence over `aggregation`.
+   */
+  valueFn?: (rows: T[], column: ColumnDefinition<T>) => any;
+  /** Static label rendered alongside / instead of the computed value (e.g. "Total"). */
+  label?: string;
+  /** Formats the computed value for display and string-based exports. */
+  formatter?: (value: any) => string;
+  /** Set to `false` to keep this column's footer out of exports. Defaults to `true`. */
+  includeInExport?: boolean;
+}
+
 export interface ColumnDefinition<T> {
   id: string;
   header: string | ((context: any) => any);
@@ -16,6 +43,14 @@ export interface ColumnDefinition<T> {
   cellEditTemplate?: TemplateRef<any>;
   headerTemplate?: TemplateRef<any>;
   footerTemplate?: TemplateRef<any>;
+  /**
+   * Simple footer reducer — analogous to `accessorFn`. Receives the column's
+   * extracted values (and the non-group rows) and returns the footer value used
+   * by the table footer and exports. Overridden by `footer` when that is set.
+   */
+  footerFn?: (values: any[], rows: T[]) => any;
+  /** Richer declarative footer; overrides `footerFn` when set. */
+  footer?: ColumnFooterConfig<T>;
   sortAction?: 'ASC' | 'DESC';
   formControlName?: string;
   groupName?: string;

--- a/projects/verben-ng-ui/src/lib/components/data-table/footer.util.ts
+++ b/projects/verben-ng-ui/src/lib/components/data-table/footer.util.ts
@@ -1,0 +1,93 @@
+import { ColumnDefinition } from './data-table.types';
+
+/**
+ * Resolves the raw value of a column for a single row, mirroring the
+ * accessor logic used to render body cells.
+ */
+export function getColumnValue<T>(row: T, column: ColumnDefinition<T>): any {
+  if (column.accessorKey != null) {
+    return (row as any)[column.accessorKey];
+  }
+  return column.accessorFn ? column.accessorFn(row) : undefined;
+}
+
+/**
+ * Computes the footer value for a column from the dataset.
+ *
+ * Value precedence: the richer `footer` config (when set) overrides the simple
+ * `footerFn`. Group header rows (added when the table is grouped) are excluded
+ * so they never skew aggregations. Returns `undefined` when the column has no
+ * footer config/fn, or has a label-only footer with no computed value.
+ */
+export function computeColumnFooter<T>(
+  column: ColumnDefinition<T>,
+  rows: readonly T[]
+): any {
+  const config = column.footer;
+  if (!config && !column.footerFn) return undefined;
+
+  const dataRows = rows.filter((row) => !(row as any)?.isGroupRow) as T[];
+
+  // `footer` config overrides the simple `footerFn`.
+  if (!config) {
+    return column.footerFn!(
+      dataRows.map((row) => getColumnValue(row, column)),
+      dataRows
+    );
+  }
+
+  if (config.valueFn) {
+    return config.valueFn(dataRows, column);
+  }
+
+  const aggregation = config.aggregation;
+  if (!aggregation) return undefined;
+
+  if (aggregation === 'count') {
+    return dataRows.length;
+  }
+
+  const numbers = dataRows
+    .map((row) => Number(getColumnValue(row, column)))
+    .filter((value) => !Number.isNaN(value));
+
+  if (numbers.length === 0) return undefined;
+
+  switch (aggregation) {
+    case 'sum':
+      return numbers.reduce((total, value) => total + value, 0);
+    case 'avg':
+      return numbers.reduce((total, value) => total + value, 0) / numbers.length;
+    case 'min':
+      return Math.min(...numbers);
+    case 'max':
+      return Math.max(...numbers);
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Renders a column's computed footer value to a display string, combining the
+ * optional `label` with the (optionally formatted) value.
+ */
+export function formatColumnFooter<T>(
+  column: ColumnDefinition<T>,
+  value: any
+): string {
+  const config = column.footer;
+  const hasValue = value !== undefined && value !== null && value !== '';
+
+  // footerFn-only (or no config): render the raw computed value.
+  if (!config) {
+    return hasValue ? String(value) : '';
+  }
+
+  const formatted = config.formatter
+    ? config.formatter(value)
+    : hasValue
+    ? String(value)
+    : '';
+
+  return [config.label, formatted].filter((part) => !!part).join(' ');
+}

--- a/projects/verben-ng-ui/src/lib/components/data-table/public-api.ts
+++ b/projects/verben-ng-ui/src/lib/components/data-table/public-api.ts
@@ -2,4 +2,5 @@ export * from './data-table.module';
 export * from './data-table.component';
 export * from './column.directive';
 export * from './data-table.types';
+export * from './footer.util';
 export * from './style.types';

--- a/projects/verben-ng-ui/src/lib/components/data-xport/data-xport.component.ts
+++ b/projects/verben-ng-ui/src/lib/components/data-xport/data-xport.component.ts
@@ -24,6 +24,8 @@ export class DataXportComponent<T> {
    * @deprecated will be removed in the near future
    */
   @Input() useImportKey: boolean = false;
+  /** Append a footer/summary row (from each column's `footer`/`footerFn`) to the export. */
+  @Input() includeFooterInExport: boolean = true;
   dataFetchUrl = input<string>();
   dataQueryParameters = input<SearchPropertyValue[]>();
   dataQueryFunction =
@@ -313,7 +315,8 @@ export class DataXportComponent<T> {
               this.exportService.exportData(
                 data,
                 selectedProfiles,
-                this.useImportKey
+                this.useImportKey,
+                this.includeFooterInExport
               );
             }
           }
@@ -322,7 +325,8 @@ export class DataXportComponent<T> {
         this.exportService.exportData(
           this.data,
           selectedProfiles,
-          this.useImportKey
+          this.useImportKey,
+          this.includeFooterInExport
         );
       }
     }

--- a/projects/verben-ng-ui/src/lib/components/data-xport/data-xport.service.ts
+++ b/projects/verben-ng-ui/src/lib/components/data-xport/data-xport.service.ts
@@ -7,7 +7,10 @@ import {
   ArithmeticOperation,
   StringOperation,
 } from './data-xport.types';
-import { ColumnDefinition } from 'verben-ng-ui/src/lib/components/data-table';
+import {
+  ColumnDefinition,
+  computeColumnFooter,
+} from 'verben-ng-ui/src/lib/components/data-table';
 import { isPrintableValue } from './data-xport.utils';
 
 @Injectable()
@@ -110,7 +113,8 @@ export class DataXportService<T> {
   exportData(
     data: T[],
     selectedProfiles: ExportProfile[],
-    useImportKey: boolean = false
+    useImportKey: boolean = false,
+    includeFooter: boolean = true
   ): Record<string, any>[] {
     const uniqueItems = new Set<ExportItem>();
     selectedProfiles.forEach((profile) => {
@@ -149,7 +153,8 @@ export class DataXportService<T> {
             ) {
               exportedItem[exportItem.name] = item[column.importKey];
             } else {
-              exportedItem[exportItem.name] = null;
+              // Export null/undefined cells as empty rather than literal null.
+              exportedItem[exportItem.name] = '';
             }
           }
         } else {
@@ -165,8 +170,50 @@ export class DataXportService<T> {
       return exportedItem;
     });
 
+    if (includeFooter) {
+      const footerRow = this.getFooterRow(data, uniqueItems);
+      if (footerRow) {
+        records.push(footerRow);
+      }
+    }
+
     this.downloadCSV(records);
     return records;
+  }
+
+  /**
+   * Builds a single footer/summary row aligned with the exported columns. Each
+   * exported item gets a key (blank by default) so the CSV stays column-aligned;
+   * property columns that define a simple `footerFn` or a richer `footer` config
+   * receive the computed value. A `footer` config can opt out via
+   * `includeInExport: false`; `footerFn`-only columns are always included.
+   * Returns `null` when no column contributes a footer.
+   */
+  getFooterRow(
+    data: T[],
+    items: Set<ExportItem> | ExportItem[]
+  ): Record<string, any> | null {
+    const uniqueItems = new Set<ExportItem>(items);
+
+    const footerRow: Record<string, any> = {};
+    let hasFooter = false;
+
+    uniqueItems.forEach((item) => {
+      footerRow[item.name] = '';
+
+      if (item.type !== 'property') return;
+
+      const column = this.columns.find((col) => col.id === item.id);
+      if (!column || (!column.footer && !column.footerFn)) return;
+      if (column.footer?.includeInExport === false) return;
+
+      const value = computeColumnFooter(column, data);
+      // Fall back to the label (or empty) so footer cells never carry null.
+      footerRow[item.name] = value ?? column.footer?.label ?? '';
+      hasFooter = true;
+    });
+
+    return hasFooter ? footerRow : null;
   }
 
   downloadCSV(data: Partial<any>[]) {


### PR DESCRIPTION
## Summary
Adds a declarative footer to `ColumnDefinition<T>` so a column can define its footer once and have it drive **both** the data-table `<tfoot>` and the `data-xport` summary row.

## What's added
- **`footerFn?: (values, rows) => any`** — simple reducer, analogous to `accessorFn` (receives the column's extracted values + the non-group rows).
- **`footer?: ColumnFooterConfig<T>`** — richer override when set: `aggregation` (`sum`/`avg`/`min`/`max`/`count`), `valueFn`, `label`, `formatter`, `includeInExport`.
- **`footerTemplate`** stays the render mechanism and always applies when set; its `$implicit` is now the **computed value** (so `let-value` works), with `column`/`data`/`value` as named context (`let-column="column"` still resolves).
- Shared **`footer.util`** (`computeColumnFooter` / `formatColumnFooter` / `getColumnValue`) — single source of truth, excludes group-header rows from aggregation. Exported from the data-table barrel for use in custom templates.
- **Exports**: `data-xport` appends a column-aligned footer/summary row (toggle via `@Input() includeFooterInExport`, default `true`), and null/undefined cells now export as empty strings instead of literal `null`.

## Value precedence
`footer` (rich config) overrides `footerFn`. `footerTemplate` controls rendering only, drawing its value from that chain.

## Usage
```ts
columns = [
  { id: 'name',  header: 'Name',  accessorKey: 'name',  footer: { label: 'Total' } },
  { id: 'price', header: 'Price', accessorKey: 'price', footerFn: (values) => values.reduce((s, v) => s + v, 0) },
];
```

## Notes
- Re-based onto `dev` (originally branched off `main` by mistake), adapted to dev's data-table refactor (virtual scroll, `DataWithKey` wrappers, extended `ColumnDefinition`, barrel exports).
- All changed files pass language-server diagnostics. A pre-existing, unrelated `verbena-icon.component.scss` issue blocks a full `ng build`; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)