### PR TITLE
fix(data-import): strip empty rows and allow multiple import cards per page

### DIFF
--- a/projects/verben-ng-ui/src/lib/components/data-import/data-import.component.html
+++ b/projects/verben-ng-ui/src/lib/components/data-import/data-import.component.html
@@ -24,7 +24,7 @@
       <button class="export-button" (click)="handleTemplateExport()">
         Download Template
       </button>
-      <label for="fileInput" class="export-button">Upload File</label>
+      <label [attr.for]="fileInputId" class="export-button">Upload File</label>
     </div>
     <hr class="divider" />
     <section class="section">
@@ -36,13 +36,15 @@
       >
         <p>
           Drag and drop files here or
-          <label for="fileInput" [style.color]="'var(--vbn-color-border-focus)'"
+          <label
+            [attr.for]="fileInputId"
+            [style.color]="'var(--vbn-color-border-focus)'"
             >click to browse</label
           >
         </p>
         <input
           type="file"
-          id="fileInput"
+          [attr.id]="fileInputId"
           (change)="onFileSelected($event)"
           style="display: none"
           accept=".csv, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.ms-excel"

--- a/projects/verben-ng-ui/src/lib/components/data-import/data-import.component.ts
+++ b/projects/verben-ng-ui/src/lib/components/data-import/data-import.component.ts
@@ -84,6 +84,10 @@ export class DataImportComponent<T extends {}> {
 
   private _ext: 'xlsx' | 'xls' | 'csv' = 'xlsx';
 
+  private static nextFileInputId = 0;
+  /** Unique per instance so several import cards can coexist on one page. */
+  readonly fileInputId = `vbn-data-import-file-${DataImportComponent.nextFileInputId++}`;
+
   files: File[] = [];
   isDragging = false;
   showPreview = false;

--- a/projects/verben-ng-ui/src/lib/components/data-import/data-import.service.ts
+++ b/projects/verben-ng-ui/src/lib/components/data-import/data-import.service.ts
@@ -8,6 +8,27 @@ export class DataImportService<T> {
 
   constructor() {}
 
+  /**
+   * A value carries no information if it is nullish, an empty/whitespace string,
+   * an invalid date, or a collection whose every member is itself blank.
+   * Numbers (including 0) and booleans (including false) are never blank.
+   */
+  private isBlankValue(value: unknown): boolean {
+    if (value === null || value === undefined) return true;
+    if (typeof value === 'string') return value.trim() === '';
+    if (value instanceof Date) return Number.isNaN(value.getTime());
+    if (Array.isArray(value)) return value.every((v) => this.isBlankValue(v));
+    if (typeof value === 'object') {
+      return Object.values(value as object).every((v) => this.isBlankValue(v));
+    }
+    return false;
+  }
+
+  private isBlankRow(row: object): boolean {
+    const values = Object.values(row);
+    return values.length === 0 || values.every((v) => this.isBlankValue(v));
+  }
+
   // Function to transform imported data to match your model structure
   transformImportData<T>(
     importedData: Record<string, any>[],
@@ -38,37 +59,44 @@ export class DataImportService<T> {
         }
       });
 
-    // Transform each row in the imported data
-    return importedData.map((row) => {
-      const transformedRow: Partial<T> = {};
+    // Transform each row in the imported data. Rows the sheet still reports but
+    // that hold nothing (whitespace, leftover formatting) are dropped up front so
+    // importBy never fabricates values out of them.
+    return importedData
+      .filter((row) => !this.isBlankRow(row))
+      .map((row) => {
+        const transformedRow: Partial<T> = {};
 
-      // Process each key in the row
-      Object.entries(row).forEach(([key, value]) => {
-        // Check if there's an importBy transformation first (takes priority)
-        const importBy = headerToImportByMap.get(key);
+        // Process each key in the row
+        Object.entries(row).forEach(([key, value]) => {
+          // Check if there's an importBy transformation first (takes priority)
+          const importBy = headerToImportByMap.get(key);
 
-        if (importBy) {
-          if (typeof importBy === 'function') {
-            // Use the importBy function to transform the entire imported row
-            const importKey = headerToImportKeyMap.get(key);
-            if (importKey) {
-              transformedRow[importKey] = importBy(row);
+          if (importBy) {
+            if (typeof importBy === 'function') {
+              // Use the importBy function to transform the entire imported row
+              const importKey = headerToImportKeyMap.get(key);
+              if (importKey) {
+                transformedRow[importKey] = importBy(row);
+              }
+            } else {
+              // importBy is a direct key reference
+              transformedRow[importBy] = value;
             }
           } else {
-            // importBy is a direct key reference
-            transformedRow[importBy] = value;
+            // Fall back to importKey if no importBy is defined
+            const importKey = headerToImportKeyMap.get(key);
+            if (importKey) {
+              transformedRow[importKey] = value;
+            }
           }
-        } else {
-          // Fall back to importKey if no importBy is defined
-          const importKey = headerToImportKeyMap.get(key);
-          if (importKey) {
-            transformedRow[importKey] = value;
-          }
-        }
-      });
+        });
 
-      return transformedRow;
-    });
+        return transformedRow;
+      })
+      // A row can still end up empty here when none of its populated cells map to
+      // an importable column.
+      .filter((row) => !this.isBlankRow(row));
   }
 
   handleImport(
@@ -93,6 +121,7 @@ export class DataImportService<T> {
       if (sheets.length) {
         const rows = utils.sheet_to_json(wb.Sheets[sheets[0]], {
           defval: null,
+          blankrows: false,
         }) as Record<string, any>[];
 
         imported = this.transformImportData(rows, columnDefinitions) as T[];

--- a/src/app/documentation/data-table/data-table.component.html
+++ b/src/app/documentation/data-table/data-table.component.html
@@ -68,20 +68,17 @@
 
 <h1 class="text-lg font-semibold my-2">Import</h1>
 
-<lib-data-import (importEventData)="log($event)" [previewColumns]="smallColsII()" title="Hello"
-  [columnTemplates]="columnTemplates()">
+<lib-data-import (importEventData)="log($event)" [previewColumns]="smallColsII()" title="Hello">
 </lib-data-import>
 
 <h1 class="text-lg font-semibold my-2">Import</h1>
 
-<lib-data-import (importEventData)="log($event)" [previewColumns]="columnnnn" title="o-a"
-  [columnTemplates]="columnTemplates()">
+<lib-data-import (importEventData)="log($event)" [previewColumns]="columnnnn" title="o-a">
 </lib-data-import>
 
 <h1 class="text-lg font-semibold my-2">Import with ImportBy (Nested Fields)</h1>
 
-<lib-data-import (importEventData)="log($event)" [previewColumns]="smallColsIII()" title="nested-import-example"
-  [columnTemplates]="columnTemplates()">
+<lib-data-import (importEventData)="log($event)" [previewColumns]="smallColsIII()" title="nested-import-example">
 </lib-data-import>
 
 <h1 class="text-lg font-semibold my-4">No Form Control</h1>

--- a/src/app/documentation/data-table/data-table.component.ts
+++ b/src/app/documentation/data-table/data-table.component.ts
@@ -229,10 +229,7 @@ export class DataTableComponent {
     {
       id: 'Name',
       header: 'Name',
-      // accessorKey: 'Name',
-      accessorFn: (row: { Name: string; Friend: string; Date: Date }) => {
-        return row;
-      },
+      accessorKey: 'Name',
       importKey: 'Name',
     },
     {
@@ -279,19 +276,6 @@ export class DataTableComponent {
       },
       canExport: true,
       canImport: true,
-      isHidden: true,
-    },
-    {
-      id: 'firstName',
-      header: 'First Name',
-      accessorFn: (row) => row.names?.firstName,
-      isHidden: false,
-    },
-    {
-      id: 'lastName',
-      header: 'Last Name',
-      accessorFn: (row) => row.names?.lastName,
-      isHidden: false,
     },
     {
       id: 'role',


### PR DESCRIPTION
## Empty rows breaking save

Excel reports a row as non-empty if any cell holds an empty string, whitespace, or leftover formatting — SheetJS only drops rows where every cell is truly absent. A sheet with trailing "cleared" rows produced objects like `{Tag: "", Name: null, ...}`, and a row whose only value sat in a column nobody imports produced a literally empty `{}`. Both flowed into the preview and then into the save call.

`data-import.service.ts` now uses a recursive `isBlankValue` (nullish, blank string, invalid date, or a collection whose members are all blank; numbers and booleans including `0`/`false` are never blank) and filters twice:

- on the raw sheet rows before mapping, so an `importBy` function never fabricates a value like `{firstName: "", lastName: ""}` out of a junk row;
- after mapping, to catch rows whose populated cells map to no importable column.

## Empty preview tables

`data-import.component.html` hardcoded `id="fileInput"` with two `<label for="fileInput">` pointing at it. With three import cards on a page, all six labels resolved to the **first** card's input — clicking card 3's "Upload File" fired card 1's input. Cards 2 and 3 were unusable, and uploading card 3's template into card 1 matched none of its headers, producing exactly the empty preview that was reported. The id is now unique per component instance.

## Documentation samples

Three real binding problems, fixed so the import behaviour is testable from `/documentation/data-table`:

- all three imports passed `[columnTemplates]="columnTemplates()"`, a page-wide `viewChildren(ColumnDirective)` that swept up the demo *data-tables'* cell templates and matched them into the preview columns by id;
- `smallColsII.Name` used `accessorFn: (row) => row`, rendering `[object Object]` in every preview row;
- the nested-import sample marked its `names` column `isHidden: true`, and `firstName`/`lastName` have no `importKey` so `previewColumnsList` filtered them out — the preview had no name column at all.

## Verification

Drove `/documentation/data-table` in headless Chrome. Each card's label now targets its own input. A sheet with two real rows plus a blank row, an empty-string row, a whitespace row, and a stray-unmapped-value row imports as exactly 2 rows. Cards 2 and 3 both populate, including the `importBy` nested-name transform. No console errors, and `ng build verben-ng-ui` passes.

No regression test was added: `ng test verben-ng-ui` does not currently compile — pre-existing type errors in `data-xport.service.spec.ts`, `verben-time-picker.component.spec.ts`, and `theme-switcher.directive.spec.ts` fail the karma run before any test executes. Worth fixing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)