### PR TITLE
fix(data-columns): emit columnsUpdated only on Save

### DIFF
--- a/projects/verben-ng-ui/src/lib/components/data-columns/data-columns.component.ts
+++ b/projects/verben-ng-ui/src/lib/components/data-columns/data-columns.component.ts
@@ -64,7 +64,7 @@ export class DataColumnsComponent<T> implements OnInit {
     const temp = this.visibleColumns[fromIndex];
     this.visibleColumns[fromIndex] = this.visibleColumns[toIndex];
     this.visibleColumns[toIndex] = temp;
-    this.emitUpdatedColumns();
+    // Staged only — applied/emitted when the user clicks Save (see template).
   }
 
   // Column Selection functionality
@@ -74,14 +74,14 @@ export class DataColumnsComponent<T> implements OnInit {
     this.visibleColumns.forEach((column) => {
       this.columnVisibility.set(column.id, newValue);
     });
-    this.emitUpdatedColumns();
+    // Staged only — applied/emitted when the user clicks Save (see template).
   }
 
   toggleColumnVisibility(columnId: string) {
     const currentValue = this.columnVisibility.get(columnId);
     this.columnVisibility.set(columnId, !currentValue);
     this.updateSelectAllStatus();
-    this.emitUpdatedColumns();
+    // Staged only — applied/emitted when the user clicks Save (see template).
   }
 
   isColumnVisible(columnId: string): boolean {


### PR DESCRIPTION
## What
The `lib-data-columns` selector emitted `columnsUpdated` on **every** checkbox toggle, select-all, and drag-reorder, *as well as* on the **Save** button. Consumers that persist column arrangement (e.g. the new per-user page-config persistence in White360FE) therefore fired a save on every single interaction.

## Change
Live mutations (toggle column, select-all, drag-reorder) now only **stage** changes in the panel. `columnsUpdated` is emitted when the user clicks **Save** (Reset still applies immediately).

## Behaviour change (all consumers)
Column changes now apply to the table on **Save** rather than live. The Save button already existed and made live-apply redundant; flagging in case any app relied on live column preview.

## Verification
- `ng build verben-ng-ui` succeeds on the `dev` base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ri1XmFuKkcRnbVQrs6Tgrk