### PR TITLE
fix(date-picker): keep the calendar overlay in the viewport; native date input in the filter panel

### DIFF
--- a/projects/verben-ng-ui/src/lib/components/data-filter/data-filter.component.html
+++ b/projects/verben-ng-ui/src/lib/components/data-filter/data-filter.component.html
@@ -90,13 +90,20 @@
 
         <!-- Value Input based on type -->
         <ng-container [ngSwitch]="currentColumnType">
-          <!-- Date Picker -->
-          <app-date-picker
+          <!-- Date Input — native rather than the library date picker, whose
+               overlay renders off screen from this narrow panel. -->
+          <verbena-input
             *ngSwitchCase="'date'"
-            placeholder="Select date"
+            type="date"
+            placeHolder="Select date"
             border="1px solid var(--vbn-color-border)"
+            borderRadius="5px"
+            textColor="var(--vbn-color-text)"
+            width="100%"
+            height="1.025rem"
+            pd="2px 6px"
             [(ngModel)]="currentFilter.value"
-          ></app-date-picker>
+          ></verbena-input>
 
           <!-- Number Input -->
           <verbena-input

--- a/projects/verben-ng-ui/src/lib/components/data-filter/data-filter.component.ts
+++ b/projects/verben-ng-ui/src/lib/components/data-filter/data-filter.component.ts
@@ -184,6 +184,14 @@ export class DataFilterComponent<T> implements OnInit, OnChanges {
     if (value instanceof Date) return value.toLocaleDateString();
     if (typeof value === 'boolean') return value ? 'Yes' : 'No';
 
+    // The native date input yields a 'YYYY-MM-DD' string; restored filters may
+    // carry one too. Parsed as local time — `new Date('2026-07-28')` is treated
+    // as UTC and would display as the previous day west of Greenwich.
+    if (typeof value === 'string' && this.isDateString(value)) {
+      const [year, month, day] = value.slice(0, 10).split('-').map(Number);
+      return new Date(year, month - 1, day).toLocaleDateString();
+    }
+
     const option = this.normalizeValueOptions(column.valueOptions).find(
       (candidate) => candidate.value === value
     );

--- a/projects/verben-ng-ui/src/lib/components/data-filter/data-filter.module.ts
+++ b/projects/verben-ng-ui/src/lib/components/data-filter/data-filter.module.ts
@@ -6,7 +6,6 @@ import { CardModule } from 'verben-ng-ui/src/lib/components/card';
 import { DropDownModule } from 'verben-ng-ui/src/lib/components/drop-down';
 import { TooltipModule } from 'verben-ng-ui/src/lib/components/tooltip';
 import { VerbenaInputModule } from 'verben-ng-ui/src/lib/verbena-input';
-import { DatePickerModule } from 'verben-ng-ui/src/lib/components/date-picker';
 import { DataFilterComponent } from './data-filter.component';
 
 @NgModule({
@@ -20,7 +19,6 @@ import { DataFilterComponent } from './data-filter.component';
     DropDownModule,
     TooltipModule,
     VerbenaInputModule,
-    DatePickerModule,
   ],
   exports: [DataFilterComponent],
 })

--- a/projects/verben-ng-ui/src/lib/components/date-picker/date-picker.component.html
+++ b/projects/verben-ng-ui/src/lib/components/date-picker/date-picker.component.html
@@ -31,6 +31,7 @@
     "
     [cdkConnectedOverlayLockPosition]="false"
     [cdkConnectedOverlayOrigin]="trigger"
+    [cdkConnectedOverlayPush]="true"
     [cdkConnectedOverlayPositions]="[
       {
         originX: 'start',
@@ -42,6 +43,18 @@
         originX: 'start',
         originY: 'top',
         overlayX: 'start',
+        overlayY: 'bottom',
+      },
+      {
+        originX: 'end',
+        originY: 'bottom',
+        overlayX: 'end',
+        overlayY: 'top',
+      },
+      {
+        originX: 'end',
+        originY: 'top',
+        overlayX: 'end',
         overlayY: 'bottom',
       },
     ]"


### PR DESCRIPTION
Follow-up to #254. That PR merged at `7b019f6`, one commit before the date-input
fix landed on the branch, so `dev` currently ships the filter panel's date field as
`app-date-picker` — the variant that renders half off screen.

## 1. Keep the calendar overlay in the viewport (`044e15b`)

The overlay's preferred positions were all `overlayX: 'start'`, differing only
vertically, so the calendar could flip above or below its trigger but **never
horizontally**. Anchored by its left edge and 400px wide, it ran off screen for any
trigger near the right of its container — in the filter panel, a ~112px cell two
thirds of the way across a 384px card. Nothing pulled it back, since
`cdkConnectedOverlay` leaves `push` disabled by default.

This appends two `end`-aligned fallback positions and enables push.

### Why this is not a breaking change

The library is consumed by many projects, so this was verified against the CDK source
rather than assumed:

- `FlexibleConnectedPositionStrategy` iterates `_preferredPositions` **in order** and
  **returns on the first position that fits entirely** (`overlay.mjs:1296-1299`).
  The new entries are *appended*, so wherever the calendar renders correctly today
  position #1 still wins and the additions are never evaluated.
- The push branch (`overlay.mjs:1339`) is only reached once **no** position fits and
  there is no flexible fit. Today that same path falls through to `overlay.mjs:1347`,
  which applies the least-bad off-screen position. Push therefore only alters the case
  that is already broken.

The diff is **13 additive lines in one template**. `date-picker.component.ts` is
untouched: no `@Input`, `@Output`, selector or module change, so **no usage site needs
any change**. `overlayWidth`/`datePickerWidth` defaults are deliberately left at 400px,
since changing those *would* alter appearance for every consumer.

**One caveat worth stating:** this is a runtime visual change in the currently-broken
case. A project that CSS-hacked around the off-screen calendar (a transform or offset on
the overlay pane) could see its workaround double-apply. Unlikely, and only affects
consumers already hitting the bug.

## 2. Native date input in the filter panel (`801452d`)

Independent of the fix above: the filter's date cell is ~112px, and a 400px calendar is
a heavy control for a trigger that small even when correctly positioned. It now uses
`verbena-input type="date"`, matching what `table-filter` already does, and drops the
unused `DatePickerModule` import.

The native input yields a `'YYYY-MM-DD'` string rather than a `Date`, so chip labels
format date strings as well as `Date` objects — parsed as local time, since
`new Date('2026-07-28')` is treated as UTC and would render as the previous day west of
Greenwich.

## Verification

- `ng build verben-ng-ui` and `ng build` both pass clean.
- **Not run:** the library test suite does not compile — `verben-time-picker.component.spec.ts:32`
  and `theme-switcher.directive.spec.ts:5` fail to type-check against current APIs, aborting
  Karma before any test executes. Both are pre-existing on `dev` and untouched here.
- **Not done:** no browser verification. The overlay fix in particular deserves a visual
  check against a right-aligned trigger — the one other in-repo usage is
  `src/app/documentation/data-table/data-table.component.html:104`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VzvAfQ8qUXinj1PRPDBwgS