### PR TITLE
feat(data-filter): required filters, per-filter edit/delete, and date-picker overlay fixes

### DIFF
--- a/projects/verben-ng-ui/src/lib/components/data-filter/data-filter.component.css
+++ b/projects/verben-ng-ui/src/lib/components/data-filter/data-filter.component.css
@@ -42,12 +42,28 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 0.5rem;
+}
+
+/* Marks the filter currently loaded into the operation row below. */
+.item-editing {
+  background-color: var(--vbn-color-surface-alt);
+  border-radius: 4px;
 }
 
 .item-label {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  /* Truncates rather than pushing the action icons off the fixed-width card. */
+  flex: 1;
+  min-width: 0;
+}
+
+.item-label label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .checkbox-label {
@@ -57,6 +73,20 @@
 .item-actions {
   display: flex;
   gap: 0.5rem;
+}
+
+.icon-button {
+  display: inline-flex;
+  align-items: center;
+  padding: 0;
+  border: none;
+  background-color: transparent;
+  cursor: pointer;
+}
+
+.icon-button[disabled] {
+  cursor: not-allowed;
+  opacity: 0.4;
 }
 
 .show-more {
@@ -79,15 +109,29 @@
   gap: 1rem;
 }
 
-.add-button {
+.operation-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.add-button,
+.clear-button {
   margin-top: 0.5rem;
   outline: none;
   border: none;
   background-color: transparent;
-  color: var(--vbn-color-border-focus);
   font-size: 0.75rem;
   font-weight: 500;
   cursor: pointer;
+}
+
+.add-button {
+  color: var(--vbn-color-border-focus);
+}
+
+.clear-button {
+  color: var(--vbn-color-text-muted);
 }
 
 .card-footer {

--- a/projects/verben-ng-ui/src/lib/components/data-filter/data-filter.component.html
+++ b/projects/verben-ng-ui/src/lib/components/data-filter/data-filter.component.html
@@ -34,10 +34,54 @@
         ></verben-svg>
       </div>
 
-      <div *ngFor="let filter of visibleFilters" class="item">
+      <div
+        *ngFor="let filter of visibleFilters"
+        class="item"
+        [class.item-editing]="isEditing(filter)"
+      >
         <div class="item-label">
-          <input type="checkbox" [(ngModel)]="filter.selected" (ngModelChange)="markTouched()" />
+          <!-- A required filter is always active, so its checkbox is ticked and
+               locked rather than hidden — the state stays readable. -->
+          <input
+            type="checkbox"
+            [(ngModel)]="filter.selected"
+            [disabled]="isRequired(filter)"
+            (ngModelChange)="markTouched()"
+          />
           <label>{{ getFilterDescription(filter) }}</label>
+        </div>
+
+        <div class="item-actions">
+          <button
+            type="button"
+            class="icon-button"
+            aria-label="Edit filter"
+            (click)="editFilter(filter)"
+          >
+            <!-- Only `stroke` is passed: `verben-svg` resolves a single colour as
+                 `fill || stroke` and applies it to both, so also passing `fill`
+                 would paint the icon in whatever `fill` holds. -->
+            <verben-svg
+              icon="edit"
+              [width]="15"
+              [height]="15"
+              stroke="var(--vbn-color-border-focus)"
+            ></verben-svg>
+          </button>
+          <button
+            type="button"
+            class="icon-button"
+            aria-label="Delete filter"
+            [disabled]="isRequired(filter)"
+            (click)="deleteFilter(filter)"
+          >
+            <verben-svg
+              icon="delete"
+              [width]="15"
+              [height]="15"
+              stroke="var(--vbn-color-error)"
+            ></verben-svg>
+          </button>
         </div>
       </div>
 
@@ -73,6 +117,7 @@
           [options]="filterableColumns"
           optionLabel="header"
           optionValue="id"
+          [disabled]="isEditingRequired"
           [(ngModel)]="currentFilter.columnId"
           (ngModelChange)="onColumnSelect($event)"
         ></verben-drop-down>
@@ -159,7 +204,12 @@
         </ng-container>
       </div>
 
-      <button class="add-button ml-auto" (click)="addFilter()">+ Add</button>
+      <div class="operation-actions">
+        <button class="clear-button" (click)="clearCurrentFilter()">
+          Clear
+        </button>
+        <button class="add-button" (click)="addFilter()">+ Add</button>
+      </div>
     </section>
   </div>
 

--- a/projects/verben-ng-ui/src/lib/components/data-filter/data-filter.component.spec.ts
+++ b/projects/verben-ng-ui/src/lib/components/data-filter/data-filter.component.spec.ts
@@ -1,23 +1,289 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ColumnDefinition, ColumnValueType } from '../data-table';
 import { DataFilterComponent } from './data-filter.component';
+import { FilterCondition } from './data-filter.types';
+
+interface Row {
+  status: string;
+  age: number;
+  isActive: boolean;
+  createdAt: string;
+}
+
+const COLUMNS: ColumnDefinition<Row>[] = [
+  {
+    id: 'status',
+    header: 'Status',
+    accessorKey: 'status',
+    valueType: ColumnValueType.Enum,
+    valueOptions: ['Draft', 'Sent', 'Paid'],
+    isRequiredFilter: true,
+  },
+  {
+    id: 'age',
+    header: 'Age',
+    accessorKey: 'age',
+    valueType: ColumnValueType.Integer,
+  },
+  {
+    id: 'isActive',
+    header: 'Active',
+    accessorKey: 'isActive',
+    valueType: ColumnValueType.Bool,
+  },
+  {
+    id: 'createdAt',
+    header: 'Created At',
+    accessorKey: 'createdAt',
+    valueType: ColumnValueType.Date,
+  },
+];
+
+/**
+ * Exercised as a plain class rather than through TestBed: every behaviour under
+ * test is component state, and the template's only inputs are `verben-svg` and
+ * `verben-drop-down`, which would each need stubbing for no added coverage.
+ */
+function makeComponent(initialFilters?: FilterCondition[]) {
+  const component = new DataFilterComponent<Row>();
+  component.columns = COLUMNS;
+  component.data = [];
+  component.initialFilters = initialFilters;
+  component.ngOnInit();
+  return component;
+}
+
+/** Fills the operation row the way the template's bindings would. */
+function fillOperationRow(
+  component: DataFilterComponent<Row>,
+  columnId: string,
+  operator: string,
+  value: FilterCondition['value']
+) {
+  component.onColumnSelect(columnId);
+  component.currentFilter.operator = operator;
+  component.currentFilter.value = value;
+}
 
 describe('DataFilterComponent', () => {
-  let component: DataFilterComponent;
-  let fixture: ComponentFixture<DataFilterComponent>;
+  describe('required filters', () => {
+    it('reports required-ness from the column definition', () => {
+      const component = makeComponent();
+      expect(
+        component.isRequired({
+          columnId: 'status',
+          operator: 'is',
+          value: 'Draft',
+        })
+      ).toBe(true);
+      expect(
+        component.isRequired({ columnId: 'age', operator: 'equal', value: 30 })
+      ).toBe(false);
+    });
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [DataFilterComponent]
-    })
-    .compileComponents();
+    it('refuses to delete a required filter but deletes an optional one', () => {
+      const component = makeComponent([
+        { columnId: 'status', operator: 'is', value: 'Draft' },
+        { columnId: 'age', operator: 'equal', value: 30 },
+      ]);
 
-    fixture = TestBed.createComponent(DataFilterComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+      component.deleteFilter(component.savedFilters[0]);
+      expect(component.savedFilters.length).toBe(2);
+
+      component.deleteFilter(component.savedFilters[1]);
+      expect(component.savedFilters.length).toBe(1);
+      expect(component.savedFilters[0].columnId).toBe('status');
+    });
+
+    it('pins required filters to the top of the visible list', () => {
+      const component = makeComponent([
+        { columnId: 'age', operator: 'equal', value: 30 },
+        { columnId: 'isActive', operator: 'is', value: true },
+        { columnId: 'createdAt', operator: 'on', value: '2026-07-31' },
+        { columnId: 'status', operator: 'is', value: 'Draft' },
+      ]);
+
+      // Fourth in the saved list, but first — and so still visible — once the
+      // list is trimmed to `maxVisibleItems`.
+      expect(component.visibleFilters.length).toBe(3);
+      expect(component.visibleFilters[0].columnId).toBe('status');
+    });
+
+    it('keeps required filters through a reset and reports what is left', () => {
+      const component = makeComponent([
+        { columnId: 'status', operator: 'is', value: 'Draft' },
+        { columnId: 'age', operator: 'equal', value: 30 },
+      ]);
+      const emitted: FilterCondition[][] = [];
+      component.filterApplied.subscribe((f) => emitted.push(f));
+      spyOn(component.resetFilter, 'emit');
+
+      component.resetAll();
+
+      expect(component.savedFilters.length).toBe(1);
+      expect(component.savedFilters[0].columnId).toBe('status');
+      expect(emitted).toEqual([
+        [{ columnId: 'status', operator: 'is', value: 'Draft' }],
+      ]);
+      expect(component.resetFilter.emit).not.toHaveBeenCalled();
+    });
+
+    it('clears everything and emits resetFilter when nothing is required', () => {
+      const component = makeComponent([
+        { columnId: 'age', operator: 'equal', value: 30 },
+      ]);
+      spyOn(component.resetFilter, 'emit');
+      spyOn(component.filterApplied, 'emit');
+
+      component.resetAll();
+
+      expect(component.savedFilters.length).toBe(0);
+      expect(component.resetFilter.emit).toHaveBeenCalled();
+      expect(component.filterApplied.emit).not.toHaveBeenCalled();
+    });
+
+    it('emits a required filter even if it is not selected', () => {
+      const component = makeComponent([
+        { columnId: 'status', operator: 'is', value: 'Draft' },
+      ]);
+      component.savedFilters[0].selected = false;
+      const emitted: FilterCondition[][] = [];
+      component.filterApplied.subscribe((f) => emitted.push(f));
+
+      component.applyFilters();
+
+      expect(emitted[0].length).toBe(1);
+      expect(component.activeFilterCount).toBe(1);
+    });
+
+    it('updates the existing chip rather than adding a second required one', () => {
+      const component = makeComponent([
+        { columnId: 'status', operator: 'is', value: 'Draft' },
+      ]);
+
+      fillOperationRow(component, 'status', 'isNot', 'Paid');
+      component.addFilter();
+
+      expect(component.savedFilters.length).toBe(1);
+      expect(component.savedFilters[0]).toEqual({
+        columnId: 'status',
+        operator: 'isNot',
+        value: 'Paid',
+        selected: true,
+      });
+    });
+
+    it('allows duplicate filters on an optional column', () => {
+      const component = makeComponent();
+
+      fillOperationRow(component, 'age', 'equal', 30);
+      component.addFilter();
+      fillOperationRow(component, 'age', 'greaterThan', 40);
+      component.addFilter();
+
+      expect(component.savedFilters.length).toBe(2);
+    });
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  describe('editing a saved filter', () => {
+    it('loads the filter into the operation row and writes it back in place', () => {
+      const component = makeComponent([
+        { columnId: 'age', operator: 'equal', value: 30 },
+        { columnId: 'status', operator: 'is', value: 'Draft' },
+      ]);
+      const target = component.savedFilters[0];
+
+      component.editFilter(target);
+      expect(component.currentFilter).toEqual({
+        columnId: 'age',
+        operator: 'equal',
+        value: 30,
+      });
+      expect(component.isEditing(target)).toBe(true);
+      expect(component.isEditingRequired).toBe(false);
+
+      component.currentFilter.value = 45;
+      component.addFilter();
+
+      expect(component.savedFilters.length).toBe(2);
+      // Same object, same position — not removed and re-added at the top.
+      expect(component.savedFilters[0]).toBe(target);
+      expect(target.value).toBe(45);
+      expect(component.isEditing(target)).toBe(false);
+      expect(component.currentFilter).toEqual({});
+    });
+
+    it('locks the property while a required filter is being edited', () => {
+      const component = makeComponent([
+        { columnId: 'status', operator: 'is', value: 'Draft' },
+      ]);
+
+      component.editFilter(component.savedFilters[0]);
+
+      expect(component.isEditingRequired).toBe(true);
+    });
+
+    it('converts a bool back to the dropdown string and to a boolean again', () => {
+      const component = makeComponent([
+        { columnId: 'isActive', operator: 'is', value: true },
+      ]);
+      const target = component.savedFilters[0];
+
+      component.editFilter(target);
+      // The dropdown's options are strings, since it gates its selected label
+      // on truthiness and would render `false` as nothing picked.
+      expect(component.currentFilter.value).toBe('true');
+
+      component.currentFilter.value = 'false';
+      component.addFilter();
+      expect(target.value).toBe(false);
+    });
+
+    it('converts a restored Date into the native input format', () => {
+      const component = makeComponent([
+        { columnId: 'createdAt', operator: 'on', value: new Date(2026, 6, 31) },
+      ]);
+
+      component.editFilter(component.savedFilters[0]);
+
+      expect(component.currentFilter.value).toBe('2026-07-31');
+    });
+
+    it('abandons the edit on clear, leaving the filter untouched', () => {
+      const component = makeComponent([
+        { columnId: 'age', operator: 'equal', value: 30 },
+      ]);
+      const target = component.savedFilters[0];
+
+      component.editFilter(target);
+      component.currentFilter.value = 99;
+      component.clearCurrentFilter();
+
+      expect(target.value).toBe(30);
+      expect(component.isEditing(target)).toBe(false);
+      expect(component.currentFilter).toEqual({});
+
+      // The next add is a plain add, not a write-back over the abandoned edit.
+      fillOperationRow(component, 'age', 'lessThan', 20);
+      component.addFilter();
+      expect(component.savedFilters.length).toBe(2);
+      expect(target.value).toBe(30);
+    });
+
+    it('drops the edit when the filter being edited is deleted', () => {
+      const component = makeComponent([
+        { columnId: 'age', operator: 'equal', value: 30 },
+      ]);
+      const target = component.savedFilters[0];
+
+      component.editFilter(target);
+      component.deleteFilter(target);
+
+      expect(component.savedFilters.length).toBe(0);
+      expect(component.currentFilter).toEqual({});
+
+      fillOperationRow(component, 'age', 'equal', 30);
+      component.addFilter();
+      expect(component.savedFilters.length).toBe(1);
+    });
   });
 });

--- a/projects/verben-ng-ui/src/lib/components/data-filter/data-filter.component.ts
+++ b/projects/verben-ng-ui/src/lib/components/data-filter/data-filter.component.ts
@@ -24,6 +24,9 @@ import {
   ENUM_OPERATORS,
 } from './data-filter.types';
 
+/** A filter chip in the panel's list: a condition plus its active state. */
+type SavedFilter = FilterCondition & { selected: boolean };
+
 @Component({
   selector: 'lib-data-filter',
   templateUrl: './data-filter.component.html',
@@ -42,7 +45,7 @@ export class DataFilterComponent<T> implements OnInit, OnChanges {
   @Output() resetFilter = new EventEmitter();
   filterableColumns: ColumnDefinition<T>[] = [];
   availableOperators: FilterOperator[] = [];
-  savedFilters: (FilterCondition & { selected: boolean })[] = [];
+  savedFilters: SavedFilter[] = [];
   currentFilter: Partial<FilterCondition> = {};
   showAllFilters = false;
   maxVisibleItems = 3;
@@ -64,6 +67,12 @@ export class DataFilterComponent<T> implements OnInit, OnChanges {
   // Set once the user edits the panel, so restored/host filters no longer
   // overwrite their in-progress work.
   private userTouched = false;
+  /**
+   * The saved filter currently loaded into the operation row, if any. Held by
+   * reference rather than by index so deleting or reordering another filter
+   * cannot retarget the write-back.
+   */
+  private editingFilter: SavedFilter | null = null;
 
   ngOnInit() {
     this.initializeFilterableColumns();
@@ -108,7 +117,15 @@ export class DataFilterComponent<T> implements OnInit, OnChanges {
     this.currentFilter.operator = undefined;
     this.currentFilter.value = undefined;
 
-    // Determine column type and set available operators
+    this.applyColumnContext(column);
+  }
+
+  /**
+   * Derives the value control, operators and options for a column without
+   * touching the operator or value already in the operation row — `editFilter`
+   * depends on those surviving, where `onColumnSelect` clears them first.
+   */
+  private applyColumnContext(column: ColumnDefinition<T>) {
     this.currentColumnType = this.resolveColumnType(column);
     this.valueOptions =
       this.currentColumnType === 'bool'
@@ -148,18 +165,108 @@ export class DataFilterComponent<T> implements OnInit, OnChanges {
       return;
     }
 
-    const newFilter: FilterCondition & { selected: boolean } = {
+    const condition: FilterCondition = {
       columnId: this.currentFilter.columnId!,
       operator: this.currentFilter.operator,
       // Bool values round-trip through the dropdown as strings; hosts receive
       // a real boolean.
       value: this.currentColumnType === 'bool' ? value === 'true' : value!,
-      selected: true,
     };
 
-    this.savedFilters.unshift(newFilter);
+    // Written back over the filter being edited, and over the existing chip of a
+    // required column, so neither case leaves a stale duplicate behind. Updated
+    // in place rather than removed and re-added so the chip keeps its position.
+    const target =
+      this.editingFilter ??
+      (this.isRequiredColumn(condition.columnId)
+        ? this.savedFilters.find((f) => f.columnId === condition.columnId)
+        : undefined);
+
+    if (target) {
+      Object.assign(target, condition);
+      target.selected = true;
+    } else {
+      this.savedFilters.unshift({ ...condition, selected: true });
+    }
+
+    this.editingFilter = null;
     this.userTouched = true;
     this.resetCurrentFilter();
+  }
+
+  /** Loads a saved filter back into the operation row for correction. */
+  editFilter(filter: SavedFilter) {
+    const column = this.filterableColumns.find(
+      (col) => col.id === filter.columnId
+    );
+    if (!column) return;
+
+    this.applyColumnContext(column);
+    this.currentFilter = {
+      columnId: filter.columnId,
+      operator: filter.operator,
+      value: this.toEditableValue(filter.value),
+    };
+    this.editingFilter = filter;
+    this.userTouched = true;
+  }
+
+  /**
+   * Converts a stored value back into what the value control expects: bools are
+   * held as real booleans but the dropdown's options are the strings
+   * 'true'/'false' (see `boolOptions`), and the native date input needs
+   * 'YYYY-MM-DD' rather than a `Date` a host may have restored.
+   */
+  private toEditableValue(value: FilterCondition['value']) {
+    if (this.currentColumnType === 'bool') return `${value}`;
+    if (value instanceof Date) {
+      // Built from the local parts: `toISOString` shifts to UTC and would move
+      // the date a day back west of Greenwich.
+      const month = `${value.getMonth() + 1}`.padStart(2, '0');
+      const day = `${value.getDate()}`.padStart(2, '0');
+      return `${value.getFullYear()}-${month}-${day}`;
+    }
+    return value;
+  }
+
+  /** Removes a saved filter. Required filters cannot be removed. */
+  deleteFilter(filter: SavedFilter) {
+    if (this.isRequired(filter)) return;
+
+    const index = this.savedFilters.indexOf(filter);
+    if (index === -1) return;
+
+    this.savedFilters.splice(index, 1);
+    if (this.editingFilter === filter) this.clearCurrentFilter();
+    this.userTouched = true;
+  }
+
+  /** Empties the operation row, abandoning any edit in progress. */
+  clearCurrentFilter() {
+    this.editingFilter = null;
+    this.resetCurrentFilter();
+  }
+
+  /** True when the filter's column is declared `isRequiredFilter`. */
+  isRequired(filter: FilterCondition): boolean {
+    return this.isRequiredColumn(filter.columnId);
+  }
+
+  private isRequiredColumn(columnId: string): boolean {
+    const column = this.filterableColumns.find((col) => col.id === columnId);
+    return !!column?.isRequiredFilter;
+  }
+
+  isEditing(filter: SavedFilter): boolean {
+    return this.editingFilter === filter;
+  }
+
+  /**
+   * Locks the property dropdown while a required filter is being edited —
+   * switching it to another column would drop the required filter entirely.
+   */
+  get isEditingRequired(): boolean {
+    return !!this.editingFilter && this.isRequired(this.editingFilter);
   }
 
   getFilterDescription(filter: FilterCondition): string {
@@ -312,15 +419,27 @@ export class DataFilterComponent<T> implements OnInit, OnChanges {
 
   resetAll() {
     this.userTouched = true;
-    this.savedFilters = [];
-    this.resetCurrentFilter();
+    this.savedFilters = this.savedFilters.filter((filter) =>
+      this.isRequired(filter)
+    );
+    this.clearCurrentFilter();
+
+    // Required filters survive a reset, so the host is told what is left rather
+    // than that everything is gone — a bare `resetFilter` would leave the panel
+    // showing chips the host is no longer filtering by.
+    if (this.savedFilters.length) {
+      this.applyFilters();
+      return;
+    }
     this.resetFilter.emit();
   }
 
   applyFilters() {
     this.userTouched = true;
     const activeFilters = this.savedFilters
-      .filter((filter) => filter.selected)
+      // Required filters are emitted whether or not they are ticked: their
+      // checkbox is disabled, but the host must never be left without them.
+      .filter((filter) => filter.selected || this.isRequired(filter))
       .map(({ columnId, operator, value }) => ({
         columnId,
         operator,
@@ -338,13 +457,26 @@ export class DataFilterComponent<T> implements OnInit, OnChanges {
       : columnId;
   }
 
-  get visibleFilters() {
+  /**
+   * Required filters pinned to the top so the collapsed list can never hide one
+   * behind "Show More".
+   */
+  get orderedFilters(): SavedFilter[] {
+    return [
+      ...this.savedFilters.filter((filter) => this.isRequired(filter)),
+      ...this.savedFilters.filter((filter) => !this.isRequired(filter)),
+    ];
+  }
+
+  get visibleFilters(): SavedFilter[] {
     return this.showAllFilters
-      ? this.savedFilters
-      : this.savedFilters.slice(0, this.maxVisibleItems);
+      ? this.orderedFilters
+      : this.orderedFilters.slice(0, this.maxVisibleItems);
   }
 
   get activeFilterCount(): number {
-    return this.savedFilters.filter((filter) => filter.selected).length;
+    return this.savedFilters.filter(
+      (filter) => filter.selected || this.isRequired(filter)
+    ).length;
   }
 }

--- a/projects/verben-ng-ui/src/lib/components/data-table/data-table.types.ts
+++ b/projects/verben-ng-ui/src/lib/components/data-table/data-table.types.ts
@@ -94,6 +94,13 @@ export interface ColumnDefinition<T> {
    * `{ label, value }` pairs when the display text differs from the stored value.
    */
   valueOptions?: string[] | ColumnValueOption[];
+  /**
+   * Marks this column's filter as required: the filter panel keeps its chip
+   * permanently active and refuses to delete it, so a page whose data cannot be
+   * fetched without the filter can never be left without one. The chip stays
+   * editable — only its removal is blocked.
+   */
+  isRequiredFilter?: boolean;
 }
 
 // Define a type that extends T with a _key property


### PR DESCRIPTION
Three commits heading to `dev`, all in the filter panel area.

## Required filters

A column can declare `isRequiredFilter`, which keeps its chip permanently active and undeletable. This exists for pages that seed the panel from the route — the account and source on a transaction group are the *identity* of the data being viewed, not a refinement of it, and nothing previously stopped a user unticking them and leaving the page unable to load.

- Checkbox ticked and disabled; delete action disabled
- Chip pinned above the "Show More" cut so it can never be hidden
- Survives Reset, and is emitted whether or not it is ticked
- A required column carries exactly one value: adding a second filter on one updates the existing chip rather than appending

**One behaviour change for existing hosts:** Reset can no longer emit a bare `resetFilter` when required chips remain — that would leave the panel showing filters the host is no longer filtering by — so it emits the surviving conditions instead. Hosts with no required columns never reach that branch and are unaffected.

## Per-filter edit and delete

Every chip gains pencil and trash actions. Editing loads the chip back into the operation row and `+ Add` writes it back **in place**, keeping its position; the new `Clear` button abandons the edit. The property dropdown is locked while a required chip is being edited, since switching it would drop the required filter entirely.

Bools round-trip through the dropdown's `'true'`/`'false'` strings and back to real booleans; a restored `Date` is converted to the native input's `YYYY-MM-DD` from local parts, not `toISOString`, which would shift the date a day back west of Greenwich.

## Also included

The two earlier commits on this branch: the date-picker calendar overlay staying within the viewport, and the switch to a native date input for date filters (the 400px calendar overlay did not fit the panel's ~112px grid cell).

## Verification

`ng build verben-ng-ui` and `ng build verben-ui` both compile clean. 14 new specs cover the required-filter and edit/write-back behaviour, replacing the stale CLI scaffold — note the library's spec suite is otherwise pre-broken (several scaffolded specs assert against properties that do not exist), so these were run with `tsconfig.spec.json` narrowed to the one file.

**Not visually verified** — browser automation was unavailable in the session. Worth an eye on the two icons at 15px in the panel's theme colours, and on a long chip label not crowding them on the 24rem card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tuTU7pLj1uAaX43ee4Gcq